### PR TITLE
Added newprob.bash for UNIX

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -4,17 +4,21 @@ A repo of solved Kattis problems. Uses [Kattis-Grind-Setup](https://github.com/J
 
 ## Usage
 
-To create a new problem, run `new-problem.bat` and type the problem id on open Kattis.
+To create a new problem, run `new-problem.bat` on Windows, or `newprob.sh` on UNIX, and type the problem id on open Kattis.
 
-The source file for the problem is given as `prog.cpp` by default.
+The source file for the problem is given as `prog.cpp` by default; it includes <bits/stdc++.h> and a main function skeleton.
 
-To run compile and run a problem, run `run.bat` inside the problem folder.
+To run compile and run a problem, run `run.bat` on Windows, or `run.sh` on UNIX, inside the problem folder.
 
-To open a link to the problem online, run `kattis.bat` inside the problem folder.
+To open a link to the problem online, run `kattis.bat` on Windows, or open `link.html` on UNIX, inside the problem folder.
 
 ## Requirements
 
 * [GCC](https://gcc.gnu.org/) / [MinGW](http://mingw.org/) 
+
+### UNIX Requirements
+* zip
+* curl
 
 ## Resources
 

--- a/Readme.md
+++ b/Readme.md
@@ -46,7 +46,7 @@ Development:
 * https://godbolt.org/
 
 Reference:
-* [JarateKings's Competitive Programming Code Snippets](https://github.com/JarateKing/Competitive-Programming-Snippets)
+* [JarateKing's Competitive Programming Code Snippets](https://github.com/JarateKing/Competitive-Programming-Snippets)
 * https://cpbook.net/
 * https://cp-algorithms.com/
 * https://www.geeksforgeeks.org/how-to-begin-with-competitive-programming/

--- a/Readme.md
+++ b/Readme.md
@@ -17,18 +17,36 @@ To open a link to the problem online, run `kattis.bat` on Windows, or open `link
 * [GCC](https://gcc.gnu.org/) / [MinGW](http://mingw.org/) 
 
 ### UNIX Requirements
+* bash
 * zip
 * curl
+* diff
+
+## UNIX Configuration Notes
+
+It is recommended to use the included GCC_ARGS since they are [the args Kattis uses](https://open.kattis.com/help/cpp).
+
+You must change the GCC_PATH to a valid G++ compiler binary path, or an equivalent alias; eg. `GCC_PATH='g++'` or `GCC_PATH='/usr/bin/g++'`
+
+Be careful when using an alias with arguments, because the GCC_ARGS variable will also be used; set them to empty string if you do not want them.
+
+### macOS Configuration
+
+It is recommended that you install [homebrew](https://brew.sh/) and use it to install gcc. This is so that you can use GNU extensions, `#include <bits/stdc++.h>`, and it is closer to Kattis' environment.
+
+You must then set GCC_PATH to `/usr/local/bin/g++-9` or equivalent.
 
 ## Resources
 
+* [Kattis Help Page](https://open.kattis.com/help)
+
 Development:
-* https://www.onlinegdb.com/online_c++_compiler
+* [Online C++ Compiler](https://www.onlinegdb.com/online_c++_compiler)
 * http://quick-bench.com
 * https://godbolt.org/
 
 Reference:
-* https://github.com/JarateKing/Competitive-Programming-Snippets
+* [JarateKings's Competitive Programming Code Snippets](https://github.com/JarateKing/Competitive-Programming-Snippets)
 * https://cpbook.net/
 * https://cp-algorithms.com/
 * https://www.geeksforgeeks.org/how-to-begin-with-competitive-programming/

--- a/Readme.md
+++ b/Readme.md
@@ -1,14 +1,19 @@
+# NOTE
+
+This concept has been extended by [Chris MacDonald at UPEI](https://github.com/chrismacdonaldw/kattis-grind).
+I will no longer maintain this repo as that version is superior. I may contribute to it in the future.
+
 # Kattis Grind
 
 A repo of solved Kattis problems. Uses [Kattis-Grind-Setup](https://github.com/JarateKing/Kattis-Grind-Setup).
 
 ## Usage
 
-To create a new problem, run `new-problem.bat` on Windows, or `newprob.sh` on UNIX, and type the problem id on open Kattis.
+To create a new problem, run `new-problem.bat` on Windows, or `newprob.bash` on UNIX, and type the problem id on open Kattis.
 
 The source file for the problem is given as `prog.cpp` by default; it includes <bits/stdc++.h> and a main function skeleton.
 
-To run compile and run a problem, run `run.bat` on Windows, or `run.sh` on UNIX, inside the problem folder.
+To run compile and run a problem, run `run.bat` on Windows, or `run.bash` on UNIX, inside the problem folder.
 
 To open a link to the problem online, run `kattis.bat` on Windows, or open `link.html` on UNIX, inside the problem folder.
 

--- a/generate-readme.py
+++ b/generate-readme.py
@@ -3,8 +3,6 @@ from os import walk
 readme = open('./Readme.md', 'w+')
 readme.write("""# Kattis Grind
 
-*"Rise and grind gamers, let's get this bread"* - PewDiePie on reviving the Third Reich.
-
 A repo of solved Kattis problems. Uses [Kattis-Grind-Setup](https://github.com/JarateKing/Kattis-Grind-Setup).
 
 ## Usage

--- a/generate-readme.py
+++ b/generate-readme.py
@@ -3,21 +3,27 @@ from os import walk
 readme = open('./Readme.md', 'w+')
 readme.write("""# Kattis Grind
 
+*"Rise and grind gamers, let's get this bread"* - PewDiePie on reviving the Third Reich.
+
 A repo of solved Kattis problems. Uses [Kattis-Grind-Setup](https://github.com/JarateKing/Kattis-Grind-Setup).
 
 ## Usage
 
-To create a new problem, run `new-problem.bat` and type the problem id on open Kattis.
+To create a new problem, run `new-problem.bat` on Windows, or `newprob.sh` on UNIX, and type the problem id on open Kattis.
 
-The source file for the problem is given as `prog.cpp` by default.
+The source file for the problem is given as `prog.cpp` by default; it includes <bits/stdc++.h> and a main function skeleton.
 
-To run compile and run a problem, run `run.bat` inside the problem folder.
+To run compile and run a problem, run `run.bat` on Windows, or `run.sh` on UNIX, inside the problem folder.
 
-To open a link to the problem online, run `kattis.bat` inside the problem folder.
+To open a link to the problem online, run `kattis.bat` on Windows, or open `link.html` on UNIX, inside the problem folder.
 
 ## Requirements
 
 * [GCC](https://gcc.gnu.org/) / [MinGW](http://mingw.org/) 
+
+### UNIX Requirements
+* zip
+* curl
 
 ## Resources
 

--- a/generate-readme.py
+++ b/generate-readme.py
@@ -1,4 +1,4 @@
-from os import walk
+from os import scandir
 
 readme = open('./Readme.md', 'w+')
 readme.write("""# Kattis Grind
@@ -39,10 +39,10 @@ Reference:
 
 """)
 problems = ''
-for (dirpath, dirnames, filenames) in walk('./problems/'):
-	if (dirpath[-1:] is not '/'):
-		problemName = dirpath.split('/')[-1:][0]
-		problemFile = dirpath + '/prog.cpp'
+for dirpath in scandir('./problems/'):
+	if dirpath.is_dir():
+		problemName = dirpath.name
+		problemFile = 'problems/' + dirpath.name + '/prog.cpp'
 		problemLink = 'https://open.kattis.com/problems/' + problemName
 		problems = problems + '* [![:link:](https://open.kattis.com/favicon)](' + problemLink + ') [' + problemName + '](' + problemFile + ')\n'
 		

--- a/generate-readme.py
+++ b/generate-readme.py
@@ -20,18 +20,36 @@ To open a link to the problem online, run `kattis.bat` on Windows, or open `link
 * [GCC](https://gcc.gnu.org/) / [MinGW](http://mingw.org/) 
 
 ### UNIX Requirements
+* bash
 * zip
 * curl
+* diff
+
+## UNIX Configuration Notes
+
+It is recommended to use the included GCC_ARGS since they are [the args Kattis uses](https://open.kattis.com/help/cpp).
+
+You must change the GCC_PATH to a valid G++ compiler binary path, or an equivalent alias; eg. `GCC_PATH='g++'` or `GCC_PATH='/usr/bin/g++'`
+
+Be careful when using an alias with arguments, because the GCC_ARGS variable will also be used; set them to empty string if you do not want them.
+
+### macOS Configuration
+
+It is recommended that you install [homebrew](https://brew.sh/) and use it to install gcc. This is so that you can use GNU extensions, `#include <bits/stdc++.h>`, and it is closer to Kattis' environment.
+
+You must then set GCC_PATH to `/usr/local/bin/g++-9` or equivalent.
 
 ## Resources
 
+* [Kattis Help Page](https://open.kattis.com/help)
+
 Development:
-* https://www.onlinegdb.com/online_c++_compiler
+* [Online C++ Compiler](https://www.onlinegdb.com/online_c++_compiler)
 * http://quick-bench.com
 * https://godbolt.org/
 
 Reference:
-* https://github.com/JarateKing/Competitive-Programming-Snippets
+* [JarateKings's Competitive Programming Code Snippets](https://github.com/JarateKing/Competitive-Programming-Snippets)
 * https://cpbook.net/
 * https://cp-algorithms.com/
 * https://www.geeksforgeeks.org/how-to-begin-with-competitive-programming/

--- a/generate-readme.py
+++ b/generate-readme.py
@@ -49,7 +49,7 @@ Development:
 * https://godbolt.org/
 
 Reference:
-* [JarateKings's Competitive Programming Code Snippets](https://github.com/JarateKing/Competitive-Programming-Snippets)
+* [JarateKing's Competitive Programming Code Snippets](https://github.com/JarateKing/Competitive-Programming-Snippets)
 * https://cpbook.net/
 * https://cp-algorithms.com/
 * https://www.geeksforgeeks.org/how-to-begin-with-competitive-programming/

--- a/get-all-problem-ids.py
+++ b/get-all-problem-ids.py
@@ -15,27 +15,26 @@ def get_ids(page_num):
                all_ids.append(link['href'].split("/")[2])
 
 
-if not os.path.exists(OUTPUT_FILE):
-     all_ids = []
-     all_threads = []
-     for i in range(25):
-          print("Starting page: ", i)
-          t = threading.Thread(target=get_ids, args=(i,))
-          t.start()
-          all_threads.append(t)
-          
-     for thread in all_threads:
+all_ids = []
+all_threads = []
+for i in range(25):
+     print("Starting page: ", i)
+     t = threading.Thread(target=get_ids, args=(i,))
+     t.start()
+     all_threads.append(t)
+     
+for thread in all_threads:
           thread.join()
 
-     print("All pages read.")
-     all_ids.sort()
-     with open(OUTPUT_FILE, 'w') as f:
-          for item in all_ids:
-               f.write("%s\n" % item)
+print("All pages read.")
+all_ids.sort()
+with open(OUTPUT_FILE, 'w') as f:
+     for item in all_ids:
+          f.write("%s\n" % item)
 
-with open(OUTPUT_FILE) as problem_list:
-     for problem_id in problem_list:
-          if os.name is 'nt':
-               os.system('new-problem.bat ' + problem_id)
-          else:
-               os.system('./newprob.sh ' + problem_id)
+
+for problem_id in all_ids:
+     if os.name is 'nt':
+          os.system('new-problem.bat ' + problem_id)
+     else:
+          os.system('./newprob.sh ' + problem_id)

--- a/get-all-problem-ids.py
+++ b/get-all-problem-ids.py
@@ -1,6 +1,9 @@
 from bs4 import BeautifulSoup
+import os
 import requests
 import threading
+
+OUTPUT_FILE = 'allProblemIDs.txt'
 
 def get_ids(page_num):
      global all_ids
@@ -10,21 +13,29 @@ def get_ids(page_num):
      for link in soup.findAll('a', href=True):
           if "/problems/" in link['href'] and link['href'].count("/") == 2:
                all_ids.append(link['href'].split("/")[2])
-     
-     
-all_ids = []
-all_threads = []
-for i in range(25):
-     print("Starting page: ", i)
-     t = threading.Thread(target=get_ids, args=(i,))
-     t.start()
-     all_threads.append(t)
-     
-for thread in all_threads:
-     thread.join()
 
-print("All pages read.")
-all_ids.sort()
-with open('allProblemIDs.txt', 'w') as f:
-    for item in all_ids:
-        f.write("%s\n" % item)
+
+if not os.path.exists(OUTPUT_FILE):
+     all_ids = []
+     all_threads = []
+     for i in range(25):
+          print("Starting page: ", i)
+          t = threading.Thread(target=get_ids, args=(i,))
+          t.start()
+          all_threads.append(t)
+          
+     for thread in all_threads:
+          thread.join()
+
+     print("All pages read.")
+     all_ids.sort()
+     with open(OUTPUT_FILE, 'w') as f:
+          for item in all_ids:
+               f.write("%s\n" % item)
+
+with open(OUTPUT_FILE) as problem_list:
+     for problem_id in problem_list:
+          if os.name is 'nt':
+               os.system('new-problem.bat ' + problem_id)
+          else:
+               os.system('./newprob.sh ' + problem_id)

--- a/get-all-problem-ids.py
+++ b/get-all-problem-ids.py
@@ -1,0 +1,30 @@
+from bs4 import BeautifulSoup
+import requests
+import threading
+
+def get_ids(page_num):
+     global all_ids
+     url = "https://open.kattis.com/problems?page=" + str(page_num)
+     page_html = requests.get(url)
+     soup = BeautifulSoup(page_html.text, 'html.parser')
+     for link in soup.findAll('a', href=True):
+          if "/problems/" in link['href'] and link['href'].count("/") == 2:
+               all_ids.append(link['href'].split("/")[2])
+     
+     
+all_ids = []
+all_threads = []
+for i in range(25):
+     print("Starting page: ", i)
+     t = threading.Thread(target=get_ids, args=(i,))
+     t.start()
+     all_threads.append(t)
+     
+for thread in all_threads:
+     thread.join()
+
+print("All pages read.")
+all_ids.sort()
+with open('allProblemIDs.txt', 'w') as f:
+    for item in all_ids:
+        f.write("%s\n" % item)

--- a/newprob.bash
+++ b/newprob.bash
@@ -9,7 +9,7 @@ if [ $# -eq 0 ]
 fi
 
 # GCC CONSTANTS
-GCC_PATH="/usr/local/bin/g++-9"
+GCC_PATH="g++"
 GCC_ARGS="-g -O2 -std=gnu++17"
 
 # PATHS AND DIRECTORIES

--- a/newprob.bash
+++ b/newprob.bash
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # PROBLEM ID INPUT
 PROB_ID=$1
@@ -28,16 +28,16 @@ echo 'int main() {' >> $PROG_PATH
 echo >> $PROG_PATH
 echo '}' >> $PROG_PATH
 
-# RUN.SH FILE CREATION
-echo \#!/bin/sh > $PROB_DIR/run.sh
-echo $GCC_PATH $GCC_ARGS prog.cpp -o prog >> $PROB_DIR/run.sh
-echo 'i=1; for TEST in ./tests/*.in; do printf "TEST CASE $i: "; ANS="${TEST%??}ans"; RESULT=$(cat $TEST | ./prog); PASS=$(echo $RESULT | diff -s - $ANS); PASS=${PASS:0:5}; if [ "$PASS" = "Files" ] ; then echo "PASS"; else echo "FAIL(P)"; fi; echo $RESULT; echo ''; ((i=$i+1)); done' >> $PROB_DIR/run.sh
-chmod +x $PROB_DIR/run.sh
+# RUN.BASH FILE CREATION
+echo \#!/bin/bash > $PROB_DIR/run.bash
+echo $GCC_PATH $GCC_ARGS prog.cpp -o prog >> $PROB_DIR/run.bash
+echo 'i=1; for TEST in ./tests/*.in; do printf "TEST CASE $i: "; ANS="${TEST%??}ans"; RESULT=$(cat $TEST | ./prog); PASS=$(echo $RESULT | diff -s - $ANS); PASS=${PASS:0:5}; if [ "$PASS" = "Files" ] ; then echo "PASS"; else echo "FAIL(P)"; fi; echo $RESULT; echo ''; ((i=$i+1)); done' >> $PROB_DIR/run.bash
+chmod +x $PROB_DIR/run.bash
 
 # LINK.HTML FILE CREATION
-echo $'<html>\n<head>\n<meta http-equiv=\"refresh\" content=\"0; url=https://open.kattis.com/problems/' > $LINK_PATH
-echo $PROB_ID >> $LINK_PATH
-echo $'\" />\n</head>\n</html>\n' >> $LINK_PATH
+printf $'<html>\n<head>\n<meta http-equiv=\"refresh\" content=\"0; url=https://open.kattis.com/problems/' > $LINK_PATH
+printf $PROB_ID >> $LINK_PATH
+printf $'\"/>\n</head>\n</html>\n' >> $LINK_PATH
 
 mkdir $TEST_DIR
 

--- a/newprob.sh
+++ b/newprob.sh
@@ -31,7 +31,7 @@ echo \} >> $PROG_PATH
 # RUN.SH FILE CREATION
 echo \#!/bin/sh > $PROB_DIR/run.sh
 echo $GCC_PATH $GCC_ARGS prog.cpp -o prog >> $PROB_DIR/run.sh
-echo "for TEST in ./tests/*.in; do cat \$TEST | ./prog; done" >> $PROB_DIR/run.sh
+echo "i=1; for TEST in ./tests/*.in; do echo \"TEST CASE $i\" && cat \$TEST | ./prog && echo '' && ((i=$i+1)); done" >> $PROB_DIR/run.sh
 chmod +x $PROB_DIR/run.sh
 
 # LINK.HTML FILE CREATION

--- a/newprob.sh
+++ b/newprob.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+PROBNAME=$1
+
+if [ $# -eq 0 ]
+  then
+    echo 'Enter problem code: '
+    read PROBNAME
+fi
+
+PROBDIR=problems/$PROBNAME
+
+mkdir -p $PROBDIR
+
+echo \#include \<bits/stdc++.h\> >> $PROBDIR/prog.cpp 
+echo using namespace std\; >> $PROBDIR/prog.cpp 
+echo >> $PROBDIR/prog.cpp
+echo int main\(\) \{ >> $PROBDIR/prog.cpp
+echo >> $PROBDIR/prog.cpp
+echo \} >> $PROBDIR/prog.cpp
+
+# NOT WORKING RIGHT NOW
+# echo g++ -g -O2 -std=gnu++17 -static prog.cpp > $PROBDIR/run.sh
+
+echo $'<html>\n<head>\n<meta http-equiv=\"refresh\" content=\"0; url=https://open.kattis.com/problems/' > $PROBDIR/link.html
+echo $PROBNAME >> $PROBDIR/link.html
+echo $'\" />\n</head>\n</html>\n' >> $PROBDIR/link.html
+
+mkdir $PROBDIR/tests
+
+curl -o $PROBDIR/samples.zip https://open.kattis.com/problems/$PROBNAME/file/statement/samples.zip
+unzip -qq $PROBDIR/samples.zip -d $PROBDIR/tests
+
+rm $PROBDIR/samples.zip

--- a/newprob.sh
+++ b/newprob.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 
 PROBNAME=$1
+GCC_PATH="/usr/local/bin/g++-9"
+GCC_ARGS="-g -O2 -std=gnu++17"
 
 if [ $# -eq 0 ]
   then
@@ -19,8 +21,10 @@ echo int main\(\) \{ >> $PROBDIR/prog.cpp
 echo >> $PROBDIR/prog.cpp
 echo \} >> $PROBDIR/prog.cpp
 
-# NOT WORKING RIGHT NOW
-# echo g++ -g -O2 -std=gnu++17 -static prog.cpp > $PROBDIR/run.sh
+echo \#!/bin/sh > $PROBDIR/run.sh
+echo $GCC_PATH $GCC_ARGS prog.cpp -o prog >> $PROBDIR/run.sh
+echo "for TEST in ./tests/*.in; do cat $TEST | ./prog; done" >> $PROBDIR/run.sh
+chmod +x $PROBDIR/run.sh
 
 echo $'<html>\n<head>\n<meta http-equiv=\"refresh\" content=\"0; url=https://open.kattis.com/problems/' > $PROBDIR/link.html
 echo $PROBNAME >> $PROBDIR/link.html

--- a/newprob.sh
+++ b/newprob.sh
@@ -21,17 +21,17 @@ TEST_DIR=$PROB_DIR/tests
 mkdir -p $PROB_DIR
 
 # PROG.CPP FILE CREATION
-echo \#include \<bits/stdc++.h\> >> $PROG_PATH 
-echo using namespace std\; >> $PROG_PATH 
+echo '#include <bits/stdc++.h>' >> $PROG_PATH 
+echo 'using namespace std;' >> $PROG_PATH 
 echo >> $PROG_PATH
-echo int main\(\) \{ >> $PROG_PATH
+echo 'int main() {' >> $PROG_PATH
 echo >> $PROG_PATH
-echo \} >> $PROG_PATH
+echo '}' >> $PROG_PATH
 
 # RUN.SH FILE CREATION
 echo \#!/bin/sh > $PROB_DIR/run.sh
 echo $GCC_PATH $GCC_ARGS prog.cpp -o prog >> $PROB_DIR/run.sh
-echo "i=1; for TEST in ./tests/*.in; do echo \"TEST CASE $i\" && cat \$TEST | ./prog && echo '' && ((i=$i+1)); done" >> $PROB_DIR/run.sh
+echo 'i=1; for TEST in ./tests/*.in; do printf "TEST CASE $i: "; ANS="${TEST%??}ans"; RESULT=$(cat $TEST | ./prog); PASS=$(echo $RESULT | diff -s - $ANS); PASS=${PASS:0:5}; if [ "$PASS" = "Files" ] ; then echo "PASS"; else echo "FAIL(P)"; fi; echo $RESULT; echo ''; ((i=$i+1)); done' >> $PROB_DIR/run.sh
 chmod +x $PROB_DIR/run.sh
 
 # LINK.HTML FILE CREATION

--- a/newprob.sh
+++ b/newprob.sh
@@ -1,38 +1,47 @@
 #!/bin/sh
 
-PROBNAME=$1
+# PROBLEM ID INPUT
+PROB_ID=$1
+if [ $# -eq 0 ]
+  then
+    printf 'Enter Problem ID: '
+    read PROB_ID
+fi
+
+# GCC CONSTANTS
 GCC_PATH="/usr/local/bin/g++-9"
 GCC_ARGS="-g -O2 -std=gnu++17"
 
-if [ $# -eq 0 ]
-  then
-    echo 'Enter problem code: '
-    read PROBNAME
-fi
+# PATHS AND DIRECTORIES
+PROB_DIR=problems/$PROB_ID
+PROG_PATH=$PROB_DIR/prog.cpp
+LINK_PATH=$PROB_DIR/link.html
+TEST_DIR=$PROB_DIR/tests
 
-PROBDIR=problems/$PROBNAME
+mkdir -p $PROB_DIR
 
-mkdir -p $PROBDIR
+# PROG.CPP FILE CREATION
+echo \#include \<bits/stdc++.h\> >> $PROG_PATH 
+echo using namespace std\; >> $PROG_PATH 
+echo >> $PROG_PATH
+echo int main\(\) \{ >> $PROG_PATH
+echo >> $PROG_PATH
+echo \} >> $PROG_PATH
 
-echo \#include \<bits/stdc++.h\> >> $PROBDIR/prog.cpp 
-echo using namespace std\; >> $PROBDIR/prog.cpp 
-echo >> $PROBDIR/prog.cpp
-echo int main\(\) \{ >> $PROBDIR/prog.cpp
-echo >> $PROBDIR/prog.cpp
-echo \} >> $PROBDIR/prog.cpp
+# RUN.SH FILE CREATION
+echo \#!/bin/sh > $PROB_DIR/run.sh
+echo $GCC_PATH $GCC_ARGS prog.cpp -o prog >> $PROB_DIR/run.sh
+echo "for TEST in ./tests/*.in; do cat \$TEST | ./prog; done" >> $PROB_DIR/run.sh
+chmod +x $PROB_DIR/run.sh
 
-echo \#!/bin/sh > $PROBDIR/run.sh
-echo $GCC_PATH $GCC_ARGS prog.cpp -o prog >> $PROBDIR/run.sh
-echo "for TEST in ./tests/*.in; do cat \$TEST | ./prog; done" >> $PROBDIR/run.sh
-chmod +x $PROBDIR/run.sh
+# LINK.HTML FILE CREATION
+echo $'<html>\n<head>\n<meta http-equiv=\"refresh\" content=\"0; url=https://open.kattis.com/problems/' > $LINK_PATH
+echo $PROB_ID >> $LINK_PATH
+echo $'\" />\n</head>\n</html>\n' >> $LINK_PATH
 
-echo $'<html>\n<head>\n<meta http-equiv=\"refresh\" content=\"0; url=https://open.kattis.com/problems/' > $PROBDIR/link.html
-echo $PROBNAME >> $PROBDIR/link.html
-echo $'\" />\n</head>\n</html>\n' >> $PROBDIR/link.html
+mkdir $TEST_DIR
 
-mkdir $PROBDIR/tests
-
-curl -s -o $PROBDIR/samples.zip https://open.kattis.com/problems/$PROBNAME/file/statement/samples.zip
-unzip -qq $PROBDIR/samples.zip -d $PROBDIR/tests
-
-rm $PROBDIR/samples.zip
+# DOWNLOADING AND UNZIPPING TESTS
+curl -s -o $PROB_DIR/samples.zip https://open.kattis.com/problems/$PROB_ID/file/statement/samples.zip
+unzip -qq $PROB_DIR/samples.zip -d $TEST_DIR
+rm $PROB_DIR/samples.zip

--- a/newprob.sh
+++ b/newprob.sh
@@ -23,7 +23,7 @@ echo \} >> $PROBDIR/prog.cpp
 
 echo \#!/bin/sh > $PROBDIR/run.sh
 echo $GCC_PATH $GCC_ARGS prog.cpp -o prog >> $PROBDIR/run.sh
-echo "for TEST in ./tests/*.in; do cat $TEST | ./prog; done" >> $PROBDIR/run.sh
+echo "for TEST in ./tests/*.in; do cat \$TEST | ./prog; done" >> $PROBDIR/run.sh
 chmod +x $PROBDIR/run.sh
 
 echo $'<html>\n<head>\n<meta http-equiv=\"refresh\" content=\"0; url=https://open.kattis.com/problems/' > $PROBDIR/link.html
@@ -32,7 +32,7 @@ echo $'\" />\n</head>\n</html>\n' >> $PROBDIR/link.html
 
 mkdir $PROBDIR/tests
 
-curl -o $PROBDIR/samples.zip https://open.kattis.com/problems/$PROBNAME/file/statement/samples.zip
+curl -s -o $PROBDIR/samples.zip https://open.kattis.com/problems/$PROBNAME/file/statement/samples.zip
 unzip -qq $PROBDIR/samples.zip -d $PROBDIR/tests
 
 rm $PROBDIR/samples.zip


### PR DESCRIPTION
Script requires curl, zip/unzip, and path to a C++ compiler.

It will:
- make a cpp file with include, namespace, and main skeleton.
- create an html file linking to the problem on open.kattis.com
- and download the test cases and unzip them into problems/$PROBLEM/tests

The run.sh file will compile prog.cpp, run it against each test case in tests/, and check the diff to report if it passed or not. FAIL(P) is used to denote that false positives are possible, in the case of a fail, manually inspect to double check.

~~Currently, this bugs out the python readme generator as it is expecting the test dirs contain programs~~ Fixed

~~I also am having trouble with getting g++ running from a script on my mac right now so I have commented out the compile/run script generation~~ Fixed